### PR TITLE
fix: test compilation, workspace path injection, and config race condition

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -1,8 +1,3 @@
-// Package main is the entry point for the API-only server.
-// It connects to PostgreSQL and serves the REST API without
-// the agent orchestrator or workspace manager — suitable for
-// cloud deployments (e.g. Render) where agent execution
-// happens on the user's local machine via the desktop app.
 package main
 
 import (
@@ -22,21 +17,17 @@ import (
 )
 
 func main() {
-	// Connect to PostgreSQL
 	database, err := db.OpenConnection()
 	if err != nil {
 		slog.Error("connecting to database", "error", err)
 		os.Exit(1)
 	}
 
-	// Run migrations
 	db.RunMigration(database)
 
-	// Initialize repositories
 	issueRepo := repository.NewPGIssueRepository(database)
 	configRepo := repository.NewPGConfigRepository(database)
 
-	// Load config from database (seed defaults on first run)
 	ctx := context.Background()
 	cfg, err := configRepo.Load(ctx)
 	if err != nil {
@@ -48,7 +39,6 @@ func main() {
 		}
 	}
 
-	// Allow PORT env var to override config
 	port := cfg.APIPort
 	if portStr := os.Getenv("PORT"); portStr != "" {
 		if p, err := strconv.Atoi(portStr); err == nil && p > 0 && p < 65536 {
@@ -56,7 +46,6 @@ func main() {
 		}
 	}
 
-	// Set up HTTP server — no orchestrator, no broadcaster
 	handler := api.NewHandler(issueRepo, configRepo, nil, cfg, nil)
 	mux := http.NewServeMux()
 	handler.RegisterRoutes(mux)
@@ -66,7 +55,6 @@ func main() {
 	addr := fmt.Sprintf(":%d", port)
 	srv := &http.Server{Addr: addr, Handler: corsHandler}
 
-	// Graceful shutdown on SIGINT/SIGTERM
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -40,8 +40,6 @@ func main() {
 	}
 }
 
-// runAPIMode starts the API-only server connected to PostgreSQL.
-// No orchestrator or agent execution — used on Render.
 func runAPIMode() {
 	slog.Info("starting in API mode (remote database, no agent execution)")
 
@@ -69,13 +67,10 @@ func runAPIMode() {
 
 	applyPortOverride(cfg)
 
-	// API mode: no orchestrator, no broadcaster
 	handler := api.NewHandler(issueRepo, configRepo, nil, cfg, nil)
 	startServer(handler, cfg.APIPort, nil)
 }
 
-// runAgentMode starts the local agent runner that talks to the remote API.
-// Runs orchestrator, workspace manager, and agents locally.
 func runAgentMode() {
 	slog.Info("starting in agent mode (remote API, local agent execution)")
 
@@ -93,26 +88,21 @@ func runAgentMode() {
 		slog.Info("GitHub token configured")
 	}
 
-	// Use default config (no database to load from)
 	cfg := config.Default()
 	applyPortOverride(cfg)
 
-	// Create API-backed issue repository that forwards to the remote backend
 	issueRepo := repository.NewAPIIssueRepository(backendURL, ghToken)
 
-	// Initialize local workspace manager
 	wsMgr, err := workspace.NewManager(cfg.Workspace.BasePath)
 	if err != nil {
 		slog.Error("initializing workspace manager", "error", err)
 		os.Exit(1)
 	}
 
-	// Initialize broadcaster and orchestrator (run agents locally)
 	broadcaster := api.NewBroadcaster()
 	orch := service.NewOrchestrator(wsMgr, issueRepo, cfg.Agent, cfg.Agent.APIKeys, broadcaster, ghToken, cfg.MaxConcurrency)
 	orch.Start()
 
-	// Serve the same API endpoints locally — Electron renderer talks to this
 	handler := api.NewHandler(issueRepo, nil, orch, cfg, broadcaster)
 	startServer(handler, cfg.APIPort, orch)
 }

--- a/backend/internal/agent/base_provider.go
+++ b/backend/internal/agent/base_provider.go
@@ -15,7 +15,6 @@ import (
 
 var prRegex = regexp.MustCompile(`https://github\.com/.+/pull/\d+`)
 
-// buildPrompt constructs the agent prompt based on mode and system prompt.
 func buildPrompt(systemPrompt, mode, issuePrompt string) string {
 	var systemCtx string
 	if systemPrompt != "" {
@@ -32,7 +31,6 @@ func buildPrompt(systemPrompt, mode, issuePrompt string) string {
 	}
 }
 
-// spawnDirect starts a command without PTY (for providers that don't need it).
 func spawnDirect(ctx context.Context, command string, args []string, workspacePath string, env []string) (*exec.Cmd, error) {
 	cmd := exec.CommandContext(ctx, command, args...)
 	cmd.Dir = workspacePath
@@ -105,7 +103,6 @@ func (tb *textBufferer) Flush() {
 	}
 }
 
-// toolVerb maps tool names to short action verbs.
 func toolVerb(name string) string {
 	verbs := map[string]string{
 		"Read":      "READ",
@@ -129,7 +126,6 @@ func toolVerb(name string) string {
 	return strings.ToUpper(name)
 }
 
-// formatToolUse formats tool input into a concise description.
 func formatToolUse(name string, input map[string]any, workspacePath string) string {
 	shortPath := func(p string) string {
 		s := strings.ReplaceAll(p, workspacePath+"/", "")
@@ -187,8 +183,6 @@ func formatToolUse(name string, input map[string]any, workspacePath string) stri
 	}
 }
 
-// plainTextParser handles output from providers that emit plain text (not JSON).
-// It emits each non-empty line as an EventText and detects PR URLs.
 func plainTextParser(ctx context.Context, scanner *bufio.Scanner, eventCh chan<- AgentEvent, result *RunResult) {
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -213,7 +207,6 @@ func plainTextParser(ctx context.Context, scanner *bufio.Scanner, eventCh chan<-
 	}
 }
 
-// baseEnv returns the base environment variables with GH tokens.
 func baseEnv(ghToken string) []string {
 	env := os.Environ()
 	if ghToken != "" {

--- a/backend/internal/agent/claude_provider.go
+++ b/backend/internal/agent/claude_provider.go
@@ -87,8 +87,7 @@ func (p *claudeProvider) RunStreaming(ctx context.Context, workspacePath, mode, 
 
 			var parsed map[string]any
 			if err := json.Unmarshal([]byte(line), &parsed); err != nil {
-				// Not JSON — emit as raw log, check for PR URL
-				select {
+					select {
 				case eventCh <- AgentEvent{Type: EventText, Timestamp: time.Now(), Prefix: "INFO", Content: strings.TrimSpace(line)}:
 				case <-ctx.Done():
 				}

--- a/backend/internal/agent/codex_provider.go
+++ b/backend/internal/agent/codex_provider.go
@@ -69,7 +69,6 @@ func (p *codexProvider) RunStreaming(ctx context.Context, workspacePath, mode, i
 		result := RunResult{}
 		var outputParts []string
 
-		// Read stderr in background
 		go func() {
 			s := bufio.NewScanner(stderr)
 			for s.Scan() {
@@ -93,10 +92,8 @@ func (p *codexProvider) RunStreaming(ctx context.Context, workspacePath, mode, i
 				continue
 			}
 
-			// Try to parse as Codex JSONL
 			var parsed map[string]any
 			if err := json.Unmarshal([]byte(line), &parsed); err != nil {
-				// Not JSON — emit as plain text, check for PR URL
 				select {
 				case eventCh <- AgentEvent{Type: EventText, Timestamp: time.Now(), Prefix: "INFO", Content: strings.TrimSpace(line)}:
 				case <-ctx.Done():
@@ -152,7 +149,6 @@ func (p *codexProvider) RunStreaming(ctx context.Context, workspacePath, mode, i
 					command, _ := item["command"].(string)
 					status, _ := item["status"].(string)
 					if command != "" && status == "completed" {
-						// Shorten the command for display
 						short := command
 						if strings.HasPrefix(short, "/usr/bin/bash -lc ") {
 							short = strings.TrimPrefix(short, "/usr/bin/bash -lc ")
@@ -165,7 +161,6 @@ func (p *codexProvider) RunStreaming(ctx context.Context, workspacePath, mode, i
 						case eventCh <- AgentEvent{Type: EventTool, Timestamp: time.Now(), Prefix: "EXEC", Content: short}:
 						case <-ctx.Done():
 						}
-						// Check aggregated output for PR URLs
 						output, _ := item["aggregated_output"].(string)
 						if match := prRegex.FindString(output); match != "" {
 							result.PRURL = match

--- a/backend/internal/agent/events.go
+++ b/backend/internal/agent/events.go
@@ -2,7 +2,6 @@ package agent
 
 import "time"
 
-// AgentEventType represents the type of streaming event from the agent.
 type AgentEventType string
 
 const (
@@ -14,7 +13,6 @@ const (
 	EventError  AgentEventType = "error"
 )
 
-// AgentEvent represents a single streaming event emitted during agent execution.
 type AgentEvent struct {
 	Type      AgentEventType `json:"type"`
 	Timestamp time.Time      `json:"timestamp"`
@@ -22,7 +20,6 @@ type AgentEvent struct {
 	Content   string         `json:"content"`
 }
 
-// RunResult contains the outcome of an agent execution.
 type RunResult struct {
 	Output   string
 	ExitCode int

--- a/backend/internal/agent/provider.go
+++ b/backend/internal/agent/provider.go
@@ -7,13 +7,11 @@ import (
 	"auto-issue/internal/config"
 )
 
-// ProviderRunner abstracts CLI-based agent execution.
 type ProviderRunner interface {
 	RunStreaming(ctx context.Context, workspacePath, mode, issuePrompt string) (<-chan AgentEvent, <-chan RunResult, error)
 	Type() string
 }
 
-// ProviderConfig holds configuration for creating a provider.
 type ProviderConfig struct {
 	Type    string
 	Model   string
@@ -23,7 +21,6 @@ type ProviderConfig struct {
 	APIKeys map[string]string // "openai" -> key, "gemini" -> key
 }
 
-// NewProvider creates the appropriate ProviderRunner for the given agent type.
 func NewProvider(cfg ProviderConfig) (ProviderRunner, error) {
 	switch cfg.Type {
 	case "claude-code":

--- a/backend/internal/agent/runner.go
+++ b/backend/internal/agent/runner.go
@@ -7,8 +7,6 @@ import (
 	"auto-issue/internal/config"
 )
 
-// Runner executes the configured agent as a local subprocess.
-// It delegates to ClaudeProvider for backward compatibility.
 type Runner struct {
 	provider ProviderRunner
 	cfg      config.AgentConfig
@@ -26,7 +24,6 @@ func NewRunner(cfg config.AgentConfig, ghToken string) *Runner {
 	return &Runner{provider: provider, cfg: cfg, ghToken: ghToken}
 }
 
-// Run executes the agent synchronously (backward compat wrapper).
 func (r *Runner) Run(ctx context.Context, workspacePath string, mode string, issuePrompt string) (RunResult, error) {
 	events, resultCh, err := r.RunStreaming(ctx, workspacePath, mode, issuePrompt)
 	if err != nil {
@@ -47,12 +44,10 @@ func (r *Runner) Run(ctx context.Context, workspacePath string, mode string, iss
 	return result, nil
 }
 
-// RunStreaming executes the agent and returns channels for streaming events and final result.
 func (r *Runner) RunStreaming(ctx context.Context, workspacePath string, mode string, issuePrompt string) (<-chan AgentEvent, <-chan RunResult, error) {
 	return r.provider.RunStreaming(ctx, workspacePath, mode, issuePrompt)
 }
 
-// command returns the CLI command name (kept for tests).
 func (r *Runner) command() string {
 	switch r.cfg.Type {
 	case "claude-code":
@@ -62,7 +57,6 @@ func (r *Runner) command() string {
 	}
 }
 
-// buildStreamArgs returns CLI args (kept for tests).
 func (r *Runner) buildStreamArgs(prompt string) []string {
 	switch r.cfg.Type {
 	case "claude-code":
@@ -78,7 +72,6 @@ func (r *Runner) buildStreamArgs(prompt string) []string {
 	}
 }
 
-// buildPromptForRunner constructs the prompt (kept for tests).
 func (r *Runner) buildPrompt(mode string, issuePrompt string) string {
 	return buildPrompt(r.cfg.Prompt, mode, issuePrompt)
 }

--- a/backend/internal/api/broadcaster.go
+++ b/backend/internal/api/broadcaster.go
@@ -10,21 +10,17 @@ import (
 	"auto-issue/internal/agent"
 )
 
-// Broadcaster manages SSE subscriptions per issue.
 type Broadcaster struct {
 	mu   sync.RWMutex
 	subs map[string]map[chan agent.AgentEvent]struct{}
 }
 
-// NewBroadcaster creates a new Broadcaster.
 func NewBroadcaster() *Broadcaster {
 	return &Broadcaster{
 		subs: make(map[string]map[chan agent.AgentEvent]struct{}),
 	}
 }
 
-// Subscribe returns a channel that receives events for the given issue
-// and an unsubscribe function.
 func (b *Broadcaster) Subscribe(issueID string) (<-chan agent.AgentEvent, func()) {
 	ch := make(chan agent.AgentEvent, 64)
 
@@ -48,8 +44,7 @@ func (b *Broadcaster) Subscribe(issueID string) (<-chan agent.AgentEvent, func()
 	return ch, unsub
 }
 
-// Broadcast sends an event to all subscribers of the given issue.
-// Non-blocking: if a subscriber's channel is full, the event is dropped for that subscriber.
+// Non-blocking: drops events for slow consumers.
 func (b *Broadcaster) Broadcast(issueID string, event agent.AgentEvent) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
@@ -63,7 +58,6 @@ func (b *Broadcaster) Broadcast(issueID string, event agent.AgentEvent) {
 	}
 }
 
-// ServeSSE handles the SSE endpoint for streaming issue events.
 func (b *Broadcaster) ServeSSE(w http.ResponseWriter, r *http.Request, issueID string) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -81,11 +75,9 @@ func (b *Broadcaster) ServeSSE(w http.ResponseWriter, r *http.Request, issueID s
 	ch, unsub := b.Subscribe(issueID)
 	defer unsub()
 
-	// Send initial keepalive
 	fmt.Fprintf(w, ": connected\n\n")
 	flusher.Flush()
 
-	// Keepalive ticker
 	ticker := time.NewTicker(15 * time.Second)
 	defer ticker.Stop()
 

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -1,5 +1,3 @@
-// Package api provides HTTP handlers that wire the frontend
-// to the backend by exposing REST endpoints for Kanban board operations.
 package api
 
 import (
@@ -7,10 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
-	"time"
-
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
 
 	"auto-issue/internal/config"
 	"auto-issue/internal/constants"
@@ -19,19 +19,16 @@ import (
 	"auto-issue/internal/service"
 )
 
-// Handler serves the auto-issue REST API, delegating to the repository
-// and orchestrator for issue lifecycle management.
 type Handler struct {
 	issues      repository.IssueRepository
 	configRepo  repository.ConfigRepository
 	orch        *service.Orchestrator
 	config      *config.Config
+	configMu    sync.RWMutex
 	broadcaster *Broadcaster
 	startTime   time.Time
 }
 
-// NewHandler creates a Handler wired to the given dependencies.
-// orch and broadcaster may be nil for API-only deployments (no agent execution).
 func NewHandler(issues repository.IssueRepository, configRepo repository.ConfigRepository, orch *service.Orchestrator, cfg *config.Config, broadcaster *Broadcaster) *Handler {
 	return &Handler{
 		issues:      issues,
@@ -43,7 +40,6 @@ func NewHandler(issues repository.IssueRepository, configRepo repository.ConfigR
 	}
 }
 
-// RegisterRoutes registers all API v1 endpoints on the given mux.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/status", h.handleStatus)
 	mux.HandleFunc("/api/v1/issues", h.handleIssues)
@@ -123,7 +119,6 @@ func (h *Handler) createIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate agent_type if provided
 	if req.AgentType != "" {
 		validTypes := map[string]bool{"claude-code": true, "codex": true, "gemini": true}
 		if !validTypes[req.AgentType] {
@@ -146,7 +141,6 @@ func (h *Handler) createIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Set agent type/model if specified
 	if req.AgentType != "" || req.AgentModel != "" {
 		if err := h.issues.UpdateAgentInfo(r.Context(), issue.IssueID, req.AgentType, req.AgentModel); err != nil {
 			writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
@@ -234,20 +228,17 @@ func (h *Handler) cancelIssue(w http.ResponseWriter, r *http.Request, id string)
 		return
 	}
 
-	// Only cancel issues that are actively running
 	if issue.Phase != constants.PhaseDeveloping && issue.Phase != constants.PhaseCodeReviewing {
 		writeError(w, http.StatusConflict, "invalid_phase", fmt.Sprintf("cannot cancel issue in phase %s", issue.Phase))
 		return
 	}
 
-	// Cancel the agent process
 	if h.orch == nil {
 		writeError(w, http.StatusServiceUnavailable, "agent_unavailable", "agent execution is not available on this server")
 		return
 	}
 	h.orch.CancelIssue(id)
 
-	// Transition to failed
 	if err := h.issues.Transition(r.Context(), id, constants.PhaseFailed); err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
 		return
@@ -354,10 +345,13 @@ func (h *Handler) submitFeedback(w http.ResponseWriter, r *http.Request, id stri
 
 	ctx := r.Context()
 
-	// Use max_iterations from request if provided, otherwise fall back to config
 	maxIter := req.MaxIterations
-	if maxIter <= 0 && h.config != nil {
-		maxIter = h.config.Agent.MaxIterations
+	if maxIter <= 0 {
+		h.configMu.RLock()
+		if h.config != nil {
+			maxIter = h.config.Agent.MaxIterations
+		}
+		h.configMu.RUnlock()
 	}
 	if maxIter <= 0 {
 		maxIter = 3 // sensible default
@@ -395,7 +389,6 @@ func (h *Handler) streamEvents(w http.ResponseWriter, r *http.Request, id string
 		return
 	}
 
-	// Verify issue exists
 	if _, err := h.issues.Get(r.Context(), id); err != nil {
 		writeError(w, http.StatusNotFound, "not_found", err.Error())
 		return
@@ -414,7 +407,10 @@ func (h *Handler) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, h.config)
+	h.configMu.RLock()
+	cfg := h.config
+	h.configMu.RUnlock()
+	writeJSON(w, http.StatusOK, cfg)
 }
 
 func (h *Handler) handleConfigReload(w http.ResponseWriter, r *http.Request) {
@@ -429,7 +425,9 @@ func (h *Handler) handleConfigReload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.configMu.Lock()
 	h.config = cfg
+	h.configMu.Unlock()
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success": true,
 		"message": "Config reloaded successfully",
@@ -453,7 +451,11 @@ func (h *Handler) getDiff(w http.ResponseWriter, r *http.Request, id string) {
 		return
 	}
 
-	// Get diff stat
+	if err := validateWorkspacePath(issue.WorkspacePath); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_workspace", err.Error())
+		return
+	}
+
 	statCmd := exec.Command("git", "diff", "HEAD~1", "--stat")
 	statCmd.Dir = issue.WorkspacePath
 	statOutput, err := statCmd.Output()
@@ -462,7 +464,6 @@ func (h *Handler) getDiff(w http.ResponseWriter, r *http.Request, id string) {
 		return
 	}
 
-	// Get full diff
 	diffCmd := exec.Command("git", "diff", "HEAD~1")
 	diffCmd.Dir = issue.WorkspacePath
 	diffOutput, err := diffCmd.Output()
@@ -471,7 +472,6 @@ func (h *Handler) getDiff(w http.ResponseWriter, r *http.Request, id string) {
 		return
 	}
 
-	// Parse diff into structured response
 	type DiffFile struct {
 		Path      string `json:"path"`
 		Status    string `json:"status"`
@@ -490,7 +490,6 @@ func (h *Handler) getDiff(w http.ResponseWriter, r *http.Request, id string) {
 	totalAdded := 0
 	totalRemoved := 0
 
-	// Parse the unified diff output into per-file patches
 	diffStr := string(diffOutput)
 	fileDiffs := strings.Split(diffStr, "diff --git ")
 
@@ -504,7 +503,6 @@ func (h *Handler) getDiff(w http.ResponseWriter, r *http.Request, id string) {
 			continue
 		}
 
-		// Extract file path from "a/path b/path"
 		parts := strings.Fields(lines[0])
 		filePath := ""
 		if len(parts) >= 2 {
@@ -554,8 +552,6 @@ func (h *Handler) getDiff(w http.ResponseWriter, r *http.Request, id string) {
 	})
 }
 
-// transitionIssue handles direct phase transitions used by the agent runner's APIIssueRepository.
-// Unlike moveIssue which only supports "in_progress" and "done", this supports all valid transitions.
 func (h *Handler) transitionIssue(w http.ResponseWriter, r *http.Request, id string) {
 	if r.Method != http.MethodPut {
 		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "only PUT is allowed")
@@ -589,6 +585,11 @@ func (h *Handler) startDeveloping(w http.ResponseWriter, r *http.Request, id str
 	}
 	if err := readJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+
+	if err := validateWorkspacePath(req.WorkspacePath); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_workspace", err.Error())
 		return
 	}
 
@@ -691,6 +692,25 @@ func (h *Handler) updateAgentInfo(w http.ResponseWriter, r *http.Request, id str
 	writeJSON(w, http.StatusOK, map[string]any{"success": true})
 }
 
+func validateWorkspacePath(wsPath string) error {
+	cleaned := filepath.Clean(wsPath)
+	if !filepath.IsAbs(cleaned) {
+		return fmt.Errorf("workspace path must be absolute")
+	}
+	info, err := os.Stat(cleaned)
+	if err != nil {
+		return fmt.Errorf("workspace path does not exist: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("workspace path is not a directory")
+	}
+	gitDir := filepath.Join(cleaned, ".git")
+	if _, err := os.Stat(gitDir); err != nil {
+		return fmt.Errorf("workspace path is not a git repository")
+	}
+	return nil
+}
+
 func writeJSON(w http.ResponseWriter, status int, data any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
@@ -711,8 +731,6 @@ func writeError(w http.ResponseWriter, status int, code string, message string) 
 	}
 }
 
-// extractGHToken pulls the GitHub token from the Authorization header.
-// Supports "Bearer <token>" and "token <token>" formats.
 func extractGHToken(r *http.Request) string {
 	auth := r.Header.Get("Authorization")
 	if auth == "" {

--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -205,7 +205,6 @@ func TestCreateIssue(t *testing.T) {
 func TestCreateIssueWithAgentType(t *testing.T) {
 	_, mux := setupTestHandler(t)
 
-	// Valid agent_type
 	w := doRequest(t, mux, "POST", "/api/v1/issues", map[string]any{
 		"title":       "Test with codex",
 		"description": "Use codex agent",
@@ -225,7 +224,6 @@ func TestCreateIssueWithAgentType(t *testing.T) {
 		t.Errorf("agent_model = %v, want o3-mini", resp["agent_model"])
 	}
 
-	// Invalid agent_type
 	w2 := doRequest(t, mux, "POST", "/api/v1/issues", map[string]any{
 		"title":       "Test with invalid",
 		"agent_type":  "invalid-provider",
@@ -489,7 +487,6 @@ func TestGetConfig(t *testing.T) {
 	}
 }
 
-// phasePath returns the sequence of transitions needed to reach the target phase from backlog.
 func phasePath(target string) []string {
 	switch target {
 	case constants.PhaseBacklog:

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -50,7 +50,6 @@ func (d Duration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.Duration.String())
 }
 
-// Default returns a Config with all default values applied.
 func Default() *Config {
 	cfg := &Config{}
 	cfg.applyDefaults()

--- a/backend/internal/constants/phases.go
+++ b/backend/internal/constants/phases.go
@@ -1,4 +1,3 @@
-// Package constants defines shared domain constants used across the application.
 package constants
 
 const (
@@ -10,7 +9,6 @@ const (
 	PhaseFailed        = "failed"
 )
 
-// validTransitions defines which phase transitions are allowed.
 var validTransitions = map[string][]string{
 	PhaseBacklog:       {PhaseDeveloping},
 	PhaseDeveloping:    {PhaseCodeReviewing, PhaseFailed},
@@ -18,7 +16,6 @@ var validTransitions = map[string][]string{
 	PhaseHumanReview:   {PhaseDeveloping, PhaseDone},
 }
 
-// IsValidTransition checks whether moving from one phase to another is allowed.
 func IsValidTransition(from, to string) bool {
 	targets, ok := validTransitions[from]
 	if !ok {

--- a/backend/internal/models/issue.go
+++ b/backend/internal/models/issue.go
@@ -2,7 +2,6 @@ package models
 
 import "time"
 
-// Issue is the GORM model for the issues table.
 type Issue struct {
 	IssueID       string     `json:"id" gorm:"primaryKey;column:issue_id"`
 	RunNumber     int        `json:"run_number" gorm:"not null;default:0"`

--- a/backend/internal/repository/api_issue_repository.go
+++ b/backend/internal/repository/api_issue_repository.go
@@ -1,5 +1,3 @@
-// Package repository provides data access implementations.
-// api_issue_repository.go implements IssueRepository via HTTP calls to a remote API.
 package repository
 
 import (
@@ -15,15 +13,12 @@ import (
 	"auto-issue/internal/models"
 )
 
-// APIIssueRepository implements IssueRepository by calling a remote REST API.
-// Used in agent mode where the local binary talks to the remote Render backend.
 type APIIssueRepository struct {
 	baseURL    string
 	authToken  string
 	httpClient *http.Client
 }
 
-// NewAPIIssueRepository creates a new HTTP-backed issue repository.
 func NewAPIIssueRepository(baseURL string, authToken string) *APIIssueRepository {
 	return &APIIssueRepository{
 		baseURL:   baseURL,
@@ -34,7 +29,6 @@ func NewAPIIssueRepository(baseURL string, authToken string) *APIIssueRepository
 	}
 }
 
-// Compile-time interface verification.
 var _ IssueRepository = (*APIIssueRepository)(nil)
 
 func (r *APIIssueRepository) doRequest(ctx context.Context, method, path string, body any) (*http.Response, error) {

--- a/backend/internal/repository/config_repository.go
+++ b/backend/internal/repository/config_repository.go
@@ -11,26 +11,21 @@ import (
 	"gorm.io/gorm"
 )
 
-// ConfigRepository defines the data access contract for configuration.
 type ConfigRepository interface {
 	Load(ctx context.Context) (*config.Config, error)
 	Save(ctx context.Context, cfg *config.Config) error
 }
 
-// PGConfigRepository implements ConfigRepository backed by PostgreSQL via GORM.
 type PGConfigRepository struct {
 	db *gorm.DB
 }
 
-// NewPGConfigRepository creates a new PostgreSQL-backed config repository.
 func NewPGConfigRepository(db *gorm.DB) *PGConfigRepository {
 	return &PGConfigRepository{db: db}
 }
 
-// Compile-time interface verification.
 var _ ConfigRepository = (*PGConfigRepository)(nil)
 
-// Load reads the singleton config row from PostgreSQL.
 func (r *PGConfigRepository) Load(ctx context.Context) (*config.Config, error) {
 	var row models.Config
 	if err := r.db.WithContext(ctx).First(&row, 1).Error; err != nil {
@@ -68,7 +63,6 @@ func (r *PGConfigRepository) Load(ctx context.Context) (*config.Config, error) {
 	return cfg, nil
 }
 
-// Save writes the config to the singleton row in PostgreSQL.
 func (r *PGConfigRepository) Save(ctx context.Context, cfg *config.Config) error {
 	row := models.Config{
 		ID:             1,

--- a/backend/internal/repository/issue_repository.go
+++ b/backend/internal/repository/issue_repository.go
@@ -1,4 +1,3 @@
-// Package repository provides data access implementations backed by PostgreSQL.
 package repository
 
 import (
@@ -12,7 +11,6 @@ import (
 	"gorm.io/gorm"
 )
 
-// IssueRepository defines the data access contract for issues.
 type IssueRepository interface {
 	Create(ctx context.Context, id, title, description, repoPath, githubUser string) (*models.Issue, error)
 	CreateWithGithub(ctx context.Context, id, title, description, repoPath, githubRepo string, issueNumber int, githubUser string) (*models.Issue, error)
@@ -28,17 +26,14 @@ type IssueRepository interface {
 	Delete(ctx context.Context, id string) error
 }
 
-// PGIssueRepository implements IssueRepository backed by PostgreSQL via GORM.
 type PGIssueRepository struct {
 	db *gorm.DB
 }
 
-// NewPGIssueRepository creates a new PostgreSQL-backed issue repository.
 func NewPGIssueRepository(db *gorm.DB) *PGIssueRepository {
 	return &PGIssueRepository{db: db}
 }
 
-// Compile-time interface verification.
 var _ IssueRepository = (*PGIssueRepository)(nil)
 
 func (r *PGIssueRepository) nextRunNumber(ctx context.Context, githubUser string) int {

--- a/backend/internal/repository/memory_issue_repository.go
+++ b/backend/internal/repository/memory_issue_repository.go
@@ -10,20 +10,17 @@ import (
 	"auto-issue/internal/models"
 )
 
-// MemoryIssueRepository is an in-memory IssueRepository used for testing.
 type MemoryIssueRepository struct {
 	mu     sync.RWMutex
 	issues map[string]*models.Issue
 }
 
-// NewMemoryIssueRepository creates a new in-memory issue repository.
 func NewMemoryIssueRepository() *MemoryIssueRepository {
 	return &MemoryIssueRepository{
 		issues: make(map[string]*models.Issue),
 	}
 }
 
-// Compile-time interface verification.
 var _ IssueRepository = (*MemoryIssueRepository)(nil)
 
 func (r *MemoryIssueRepository) nextRunNumber(githubUser string) int {

--- a/backend/internal/service/orchestrator.go
+++ b/backend/internal/service/orchestrator.go
@@ -1,4 +1,3 @@
-// Package service contains business logic for the auto-issue application.
 package service
 
 import (
@@ -16,20 +15,15 @@ import (
 	"auto-issue/internal/workspace"
 )
 
-// EventBroadcaster defines the interface for broadcasting agent events.
-// Defined here to avoid import cycles with the api package.
 type EventBroadcaster interface {
 	Broadcast(issueID string, event agent.AgentEvent)
 }
 
-// IssueRequest represents an issue enqueued for processing.
 type IssueRequest struct {
 	IssueID string
-	GHToken string // per-request GitHub token from the user's OAuth session
+	GHToken string
 }
 
-// Orchestrator coordinates the issue lifecycle by dispatching work
-// to the agent runner and managing phase transitions.
 type Orchestrator struct {
 	workspace   *workspace.Manager
 	issues      repository.IssueRepository
@@ -38,15 +32,14 @@ type Orchestrator struct {
 	broadcaster EventBroadcaster
 	ghToken     string
 	queue       chan IssueRequest
-	sem         chan struct{} // concurrency limiter
+	sem         chan struct{}
 	wg          sync.WaitGroup
 	ctx         context.Context
 	cancel      context.CancelFunc
 	mu          sync.Mutex
-	cancels     map[string]context.CancelFunc // per-issue cancel functions
+	cancels     map[string]context.CancelFunc
 }
 
-// NewOrchestrator creates an Orchestrator wired to the given dependencies.
 func NewOrchestrator(ws *workspace.Manager, issues repository.IssueRepository, defaultCfg config.AgentConfig, apiKeys map[string]string, broadcaster EventBroadcaster, ghToken string, maxConcurrency int) *Orchestrator {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Orchestrator{
@@ -64,18 +57,14 @@ func NewOrchestrator(ws *workspace.Manager, issues repository.IssueRepository, d
 	}
 }
 
-// Start begins consuming from the work queue.
 func (o *Orchestrator) Start() {
 	go o.consumeLoop()
 }
 
-// Enqueue adds an issue to the work queue.
-// ghToken is the user's GitHub OAuth token; if empty, falls back to the server-wide token.
 func (o *Orchestrator) Enqueue(issueID string, ghToken string) {
 	o.queue <- IssueRequest{IssueID: issueID, GHToken: ghToken}
 }
 
-// CancelIssue cancels a running issue's agent process and transitions it to failed.
 func (o *Orchestrator) CancelIssue(issueID string) bool {
 	o.mu.Lock()
 	cancelFn, ok := o.cancels[issueID]
@@ -87,7 +76,6 @@ func (o *Orchestrator) CancelIssue(issueID string) bool {
 	return false
 }
 
-// Shutdown stops accepting new work and waits for active workers to finish.
 func (o *Orchestrator) Shutdown() {
 	o.cancel()
 	close(o.queue)
@@ -126,12 +114,10 @@ func (o *Orchestrator) broadcastEvent(issueID string, eventType agent.AgentEvent
 }
 
 func (o *Orchestrator) processIssue(issueID string, ghToken string) error {
-	// Fall back to server-wide token if no per-request token provided
 	if ghToken == "" {
 		ghToken = o.ghToken
 	}
 
-	// Create per-issue context for cancellation
 	issueCtx, issueCancel := context.WithCancel(o.ctx)
 	defer issueCancel()
 
@@ -153,7 +139,6 @@ func (o *Orchestrator) processIssue(issueID string, ghToken string) error {
 		return fmt.Errorf("issue %s is in phase %s, expected developing", issueID, issue.Phase)
 	}
 
-	// Resolve agent type and model (per-issue overrides global default)
 	agentType := issue.AgentType
 	if agentType == "" {
 		agentType = o.defaultCfg.Type
@@ -179,13 +164,10 @@ func (o *Orchestrator) processIssue(issueID string, ghToken string) error {
 
 	o.broadcastEvent(issueID, agent.EventStatus, "INFO", "Preparing workspace...")
 
-	// Step 1: Create or reuse workspace
 	var wsPath string
 	if issue.GithubRepo != "" {
-		// Remote GitHub repo — use worktree from cached clone
 		wsPath, err = o.workspace.CreateFromRemote(issueID, issue.GithubRepo, ghToken)
 	} else {
-		// Local repo — use worktree from local path
 		wsPath, err = o.workspace.Create(issueID, issue.RepoPath)
 	}
 	if err != nil {
@@ -200,16 +182,13 @@ func (o *Orchestrator) processIssue(issueID string, ghToken string) error {
 		return fmt.Errorf("starting development: %w", err)
 	}
 
-	// Step 2: Build prompt with issue context + any feedback
 	prompt := buildIssuePrompt(issue)
 
-	// Step 3: Run agent in developing mode with streaming
 	o.broadcastEvent(issueID, agent.EventStatus, "PHASE", "developing")
 	slog.Info("starting development", "issue", issueID, "iteration", issue.Iteration)
 
 	devResult, err := o.runAgentStreaming(issueCtx, issueID, provider, wsPath, "developing", prompt)
 	if err != nil {
-		// Use background context for DB writes since issueCtx may be cancelled
 		bgCtx := context.Background()
 		o.issues.UpdateOutput(bgCtx, issueID, devResult.Output, err.Error())
 		o.issues.Transition(bgCtx, issueID, constants.PhaseFailed)
@@ -222,7 +201,6 @@ func (o *Orchestrator) processIssue(issueID string, ghToken string) error {
 
 	o.issues.UpdateOutput(issueCtx, issueID, devResult.Output, fmt.Sprintf("Development completed in %s", devResult.Duration))
 
-	// Save PR URL and cost if detected during development
 	if devResult.PRURL != "" {
 		o.issues.UpdatePR(issueCtx, issueID, devResult.PRURL)
 	}
@@ -230,13 +208,11 @@ func (o *Orchestrator) processIssue(issueID string, ghToken string) error {
 		o.issues.UpdateCost(issueCtx, issueID, devResult.CostUSD, devResult.Turns)
 	}
 
-	// Step 4: Transition to code reviewing
 	o.broadcastEvent(issueID, agent.EventStatus, "PHASE", "code_reviewing")
 	if err := o.issues.Transition(issueCtx, issueID, constants.PhaseCodeReviewing); err != nil {
 		return fmt.Errorf("transition to code_reviewing: %w", err)
 	}
 
-	// Step 5: Run agent in code review mode with streaming
 	slog.Info("starting code review", "issue", issueID)
 	reviewResult, err := o.runAgentStreaming(issueCtx, issueID, provider, wsPath, "code_reviewing", prompt)
 	if err != nil {
@@ -250,22 +226,18 @@ func (o *Orchestrator) processIssue(issueID string, ghToken string) error {
 		return fmt.Errorf("code review run: %w", err)
 	}
 
-	// Append review output to existing output
 	combinedOutput := devResult.Output + "\n\n---\n\n# Code Review\n\n" + reviewResult.Output
 	combinedLogs := fmt.Sprintf("Development: %s\nCode Review: %s", devResult.Duration, reviewResult.Duration)
 	o.issues.UpdateOutput(issueCtx, issueID, combinedOutput, combinedLogs)
 
-	// Update total cost (dev + review)
 	totalCost := devResult.CostUSD + reviewResult.CostUSD
 	totalTurns := devResult.Turns + reviewResult.Turns
 	o.issues.UpdateCost(issueCtx, issueID, totalCost, totalTurns)
 
-	// Save PR URL if detected during review
 	if reviewResult.PRURL != "" && devResult.PRURL == "" {
 		o.issues.UpdatePR(issueCtx, issueID, reviewResult.PRURL)
 	}
 
-	// Step 6: Move to human review
 	o.broadcastEvent(issueID, agent.EventStatus, "PHASE", "human_review")
 	if err := o.issues.Transition(issueCtx, issueID, constants.PhaseHumanReview); err != nil {
 		return fmt.Errorf("transition to human_review: %w", err)
@@ -278,14 +250,12 @@ func (o *Orchestrator) processIssue(issueID string, ghToken string) error {
 	return nil
 }
 
-// runAgentStreaming runs the agent and broadcasts all events to SSE subscribers.
 func (o *Orchestrator) runAgentStreaming(ctx context.Context, issueID string, provider agent.ProviderRunner, wsPath string, mode string, prompt string) (agent.RunResult, error) {
 	events, resultCh, err := provider.RunStreaming(ctx, wsPath, mode, prompt)
 	if err != nil {
 		return agent.RunResult{}, err
 	}
 
-	// Forward all events to broadcaster
 	for evt := range events {
 		if o.broadcaster != nil {
 			o.broadcaster.Broadcast(issueID, evt)
@@ -301,7 +271,6 @@ func (o *Orchestrator) runAgentStreaming(ctx context.Context, issueID string, pr
 }
 
 func buildIssuePrompt(issue *models.Issue) string {
-	// Use GitHub-aware prompt when we have GitHub repo info
 	if issue.GithubRepo != "" && issue.IssueNumber > 0 {
 		prompt := fmt.Sprintf(`You are working on the repository %s. Fix GitHub issue #%d.
 
@@ -331,7 +300,6 @@ Use `+"`"+`gh pr create --title "Fix #%d: %s" --body "Closes #%d"`+"`"+` to crea
 		return prompt
 	}
 
-	// Fallback: original simple prompt for local repos
 	prompt := fmt.Sprintf("# Issue: %s\n\n%s", issue.Title, issue.Description)
 
 	if issue.LastFeedback != "" {

--- a/backend/internal/service/orchestrator_test.go
+++ b/backend/internal/service/orchestrator_test.go
@@ -17,7 +17,6 @@ import (
 	"auto-issue/internal/workspace"
 )
 
-// noopBroadcaster implements EventBroadcaster for testing.
 type noopBroadcaster struct{}
 
 func (n *noopBroadcaster) Broadcast(issueID string, event agent.AgentEvent) {}
@@ -25,30 +24,24 @@ func (n *noopBroadcaster) Broadcast(issueID string, event agent.AgentEvent) {}
 func setupTestEnv(t *testing.T) (*Orchestrator, repository.IssueRepository, string) {
 	t.Helper()
 
-	// Create a fake repo with git init
 	repoDir := filepath.Join(t.TempDir(), "repo")
 	os.MkdirAll(repoDir, 0755)
 	initGitRepo(t, repoDir)
 
-	// Create a fake "claude" script that echoes the prompt
 	binDir := t.TempDir()
 	fakeAgent := filepath.Join(binDir, "claude")
 	os.WriteFile(fakeAgent, []byte("#!/bin/sh\necho \"Agent output for: $*\""), 0755)
 
-	// Add fake agent to PATH
 	os.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
-	// Issue repository (in-memory)
 	issueRepo := repository.NewMemoryIssueRepository()
 
-	// Workspace manager
 	wsBase := filepath.Join(t.TempDir(), "workspaces")
 	ws, err := workspace.NewManager(wsBase)
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
 
-	// Agent config with short timeout
 	agentCfg := config.AgentConfig{
 		Type:    "claude-code",
 		Model:   "test-model",
@@ -84,7 +77,7 @@ func TestProcessIssueFullCycle(t *testing.T) {
 	repo.Create(ctx, "issue-1", "Add feature", "Implement the feature", repoDir, "testuser")
 	repo.Transition(ctx, "issue-1", constants.PhaseDeveloping)
 
-	err := orch.processIssue("issue-1")
+	err := orch.processIssue("issue-1", "")
 	if err != nil {
 		t.Fatalf("processIssue: %v", err)
 	}
@@ -108,7 +101,7 @@ func TestProcessIssueWithFeedback(t *testing.T) {
 
 	repo.Create(ctx, "issue-1", "Add feature", "Implement the feature", repoDir, "testuser")
 	repo.Transition(ctx, "issue-1", constants.PhaseDeveloping)
-	orch.processIssue("issue-1")
+	orch.processIssue("issue-1", "")
 
 	err := repo.SetFeedback(ctx, "issue-1", "Add unit tests please", 3)
 	if err != nil {
@@ -120,7 +113,7 @@ func TestProcessIssueWithFeedback(t *testing.T) {
 		t.Fatalf("phase after feedback = %s, want developing", issue.Phase)
 	}
 
-	err = orch.processIssue("issue-1")
+	err = orch.processIssue("issue-1", "")
 	if err != nil {
 		t.Fatalf("processIssue iteration 2: %v", err)
 	}
@@ -139,7 +132,7 @@ func TestProcessIssueWrongPhase(t *testing.T) {
 	defer orch.Shutdown()
 
 	repo.Create(context.Background(), "issue-1", "Feature", "Desc", repoDir, "testuser")
-	err := orch.processIssue("issue-1")
+	err := orch.processIssue("issue-1", "")
 	if err == nil {
 		t.Fatal("expected error for wrong phase")
 	}
@@ -154,7 +147,7 @@ func TestEnqueueAndProcess(t *testing.T) {
 	repo.Create(ctx, "issue-1", "Feature", "Build it", repoDir, "testuser")
 	repo.Transition(ctx, "issue-1", constants.PhaseDeveloping)
 
-	orch.Enqueue("issue-1")
+	orch.Enqueue("issue-1", "")
 
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
@@ -177,7 +170,7 @@ func TestConcurrentIssues(t *testing.T) {
 		id := fmt.Sprintf("issue-%d", i)
 		repo.Create(ctx, id, fmt.Sprintf("Feature %d", i), "Build it", repoDir, "testuser")
 		repo.Transition(ctx, id, constants.PhaseDeveloping)
-		orch.Enqueue(id)
+		orch.Enqueue(id, "")
 	}
 
 	deadline := time.Now().Add(15 * time.Second)

--- a/backend/internal/workspace/manager.go
+++ b/backend/internal/workspace/manager.go
@@ -31,18 +31,13 @@ func NewManager(basePath string) (*Manager, error) {
 	return &Manager{basePath: abs, clonePath: cloneDir}, nil
 }
 
-// Create initializes a workspace for the given issue using git worktree.
-// For local repos, it creates a worktree from the repo.
-// If the workspace already exists, it returns the existing path (idempotent).
 func (m *Manager) Create(issueID string, repoPath string) (string, error) {
 	wsPath := m.Path(issueID)
 
-	// Idempotent: if workspace already exists, reuse it
 	if info, err := os.Stat(wsPath); err == nil && info.IsDir() {
 		return wsPath, nil
 	}
 
-	// Validate repo path exists
 	info, err := os.Stat(repoPath)
 	if err != nil {
 		return "", fmt.Errorf("repo path %q: %w", repoPath, err)
@@ -51,7 +46,6 @@ func (m *Manager) Create(issueID string, repoPath string) (string, error) {
 		return "", fmt.Errorf("repo path %q is not a directory", repoPath)
 	}
 
-	// Create worktree from the local repo
 	branch := fmt.Sprintf("auto-issue/%s", issueID)
 	cmd := exec.Command("git", "worktree", "add", "-b", branch, wsPath, "HEAD")
 	cmd.Dir = repoPath
@@ -63,23 +57,18 @@ func (m *Manager) Create(issueID string, repoPath string) (string, error) {
 	return wsPath, nil
 }
 
-// CreateFromRemote initializes a workspace for a GitHub repo.
-// It maintains a base clone in ~/.auto-issue/clones/ and creates worktrees from it.
 func (m *Manager) CreateFromRemote(issueID string, repo string, ghToken string) (string, error) {
 	wsPath := m.Path(issueID)
 
-	// Idempotent
 	if info, err := os.Stat(wsPath); err == nil && info.IsDir() {
 		return wsPath, nil
 	}
 
-	// Ensure we have a base clone
 	cloneDir, err := m.ensureClone(repo, ghToken)
 	if err != nil {
 		return "", fmt.Errorf("ensuring clone: %w", err)
 	}
 
-	// Fetch latest
 	fetchCmd := exec.Command("git", "fetch", "origin")
 	fetchCmd.Dir = cloneDir
 	fetchCmd.Env = append(os.Environ(), fmt.Sprintf("GH_TOKEN=%s", ghToken), fmt.Sprintf("GITHUB_TOKEN=%s", ghToken))
@@ -87,7 +76,6 @@ func (m *Manager) CreateFromRemote(issueID string, repo string, ghToken string) 
 		return "", fmt.Errorf("git fetch: %s: %w", string(output), err)
 	}
 
-	// Create worktree
 	branch := fmt.Sprintf("auto-issue/%s", issueID)
 	cmd := exec.Command("git", "worktree", "add", "-b", branch, wsPath, "origin/HEAD")
 	cmd.Dir = cloneDir
@@ -99,9 +87,7 @@ func (m *Manager) CreateFromRemote(issueID string, repo string, ghToken string) 
 	return wsPath, nil
 }
 
-// ensureClone ensures a base clone exists for the given repo.
 func (m *Manager) ensureClone(repo string, ghToken string) (string, error) {
-	// Sanitize repo name for directory
 	safeName := strings.ReplaceAll(repo, "/", "--")
 	cloneDir := filepath.Join(m.clonePath, safeName)
 
@@ -126,12 +112,10 @@ func (m *Manager) ensureClone(repo string, ghToken string) (string, error) {
 	return cloneDir, nil
 }
 
-// Path returns the deterministic workspace path for a given issue.
 func (m *Manager) Path(issueID string) string {
 	return filepath.Join(m.basePath, issueID)
 }
 
-// Cleanup removes the workspace worktree and branch for an issue.
 func (m *Manager) Cleanup(issueID string) error {
 	wsPath := m.Path(issueID)
 
@@ -139,8 +123,6 @@ func (m *Manager) Cleanup(issueID string) error {
 		return nil // already gone
 	}
 
-	// Try to remove as worktree first
-	// Find the parent repo by checking .git file in worktree
 	gitFile := filepath.Join(wsPath, ".git")
 	if data, err := os.ReadFile(gitFile); err == nil {
 		// .git file in worktree contains "gitdir: /path/to/repo/.git/worktrees/..."
@@ -170,14 +152,12 @@ func (m *Manager) Cleanup(issueID string) error {
 		}
 	}
 
-	// Fallback: just remove the directory
 	if err := os.RemoveAll(wsPath); err != nil {
 		return fmt.Errorf("removing workspace %q: %w", wsPath, err)
 	}
 	return nil
 }
 
-// Exists checks if a workspace directory exists for the given issue.
 func (m *Manager) Exists(issueID string) bool {
 	info, err := os.Stat(m.Path(issueID))
 	return err == nil && info.IsDir()


### PR DESCRIPTION

- Add missing ghToken argument to processIssue/Enqueue calls in orchestrator tests
- Validate workspace paths (absolute, exists, is git repo) before use in getDiff and startDeveloping
- Guard h.config with sync.RWMutex to prevent data race between handleConfigReload and concurrent readers
- Strip redundant comments across the codebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed control flow in agent response streaming to properly handle non-JSON output.

* **Improvements**
  * Workspace path validation now enforces absolute paths and Git repository structure.
  * Configuration management now uses synchronized access to prevent concurrent conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->